### PR TITLE
Fix compilation error in Linux.

### DIFF
--- a/sock/sockopts.c
+++ b/sock/sockopts.c
@@ -11,6 +11,10 @@
 #include	<fcntl.h>
 #include	<sys/ioctl.h>
 
+#ifdef	FIOASYNC
+	static void sigio_func(int);
+#endif
+
 void
 sockopts(int sockfd, int doall)
 {
@@ -328,8 +332,6 @@ sockopts(int sockfd, int doall)
 
     if (sigio) {
 #ifdef	FIOASYNC
-		static void sigio_func(int);
-
 		/*
 		 * Should be able to set this with fcntl(O_ASYNC) or fcntl(FASYNC),
 		 * but some systems (AIX?) only do it with ioctl().


### PR DESCRIPTION
This had happened, error: invalid storage class for function ‘sigio_func’.  
However, this is a work around.